### PR TITLE
Add Docker E2E test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - make deps
 script:
   - make test
+  - make docker-test
 before_deploy:
   - GOOS=linux GOARCH=amd64 make
   - make cross-build

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,12 @@ ifeq ($(findstring ELF 64-bit LSB,$(shell file bin/$(NAME) 2> /dev/null)),)
 endif
 	docker build -t $(DOCKER_IMAGE) .
 
+.PHONY: docker-test
+docker-test:
+	GOOS=linux GOARCH=amd64 $(MAKE)
+	$(MAKE) docker-build
+	docker run --rm $(DOCKER_IMAGE) version
+
 .PHONY: glide
 glide:
 ifeq ($(shell command -v glide 2> /dev/null),)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION := v0.2.0
 REVISION := $(shell git rev-parse --short HEAD)
 
 SRCS    := $(shell find . -type f -name '*.go')
-LDFLAGS := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\" -extldflags \"-static\""
+LDFLAGS := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\" -linkmode external -extldflags -static"
 
 DIST_DIRS := find * -type d -exec
 


### PR DESCRIPTION
## WHY

Current k8sec Docker image is NOT executable.

```bash
$ docker run --rm quay.io/dtan4/k8sec version
standard_init_linux.go:175: exec user process caused "no such file or directory"
```

Essential libraries is lacked so that binary was built as dynamic-link binary.

```bash
/ # file k8sec
k8sec: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, stripped
```

## WHAT

Check whether the built Docker image runs correctly or not. Build _static_-link binary at all time.

## REF

[rkt - how to create a statically linked golang executable with go 1.5+ - Stack Overflow](http://stackoverflow.com/questions/33113190/how-to-create-a-statically-linked-golang-executable-with-go-1-5)