### PR TITLE
Create new secret if it does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ docker-test:
 	$(MAKE) docker-build
 	docker run --rm $(DOCKER_IMAGE) version
 
+.PHONY: fast
+fast:
+	go build $(LDFLAGS) -o bin/$(NAME)
+
 .PHONY: glide
 glide:
 ifeq ($(shell command -v glide 2> /dev/null),)

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -81,8 +81,12 @@ func doSet(cmd *cobra.Command, args []string) error {
 		return errors.Wrapf(err, "Failed to get current secret. name=%s", name)
 	}
 
-	for k, v := range data {
-		s.Data[k] = v
+	if s.Data == nil {
+		s.Data = data
+	} else {
+		for k, v := range data {
+			s.Data[k] = v
+		}
 	}
 
 	_, err = clientset.Core().Secrets(rootOpts.namespace).Update(s)


### PR DESCRIPTION
## WHY

If target secret does not exist, valec returns error.
To resolve this, we have to create new secret using `kubectl`.

```bash
$ kubectl create secret generic name
```

## WHAT

If target secret does not exist, create new secret and then set the given secret values.