### PR TITLE
Check the length of key=value array

### DIFF
--- a/cmd/set.go
+++ b/cmd/set.go
@@ -54,7 +54,7 @@ func doSet(cmd *cobra.Command, args []string) error {
 	for _, kv := range args[1:] {
 		ary := strings.SplitN(kv, "=", 2)
 
-		if len(args) != 2 {
+		if len(ary) != 2 {
 			return errors.Errorf("Argument should be in key=value format. argument=%q", kv)
 		}
 


### PR DESCRIPTION
## WHY

Current k8sec fails to set multiple key=values.

```bash
$ bin/k8sec set dotenv HOGE=fuga FOO=bar --namespace awesome
Error: Argument should be in key=value format. argument="HOGE=fuga"
```

## WHAT

Enable `k8sec set` to set multiple key=values.

```bash
$ bin/k8sec set dotenv HOGE=fuga FOO=bar --namespace awesome
dotenv
```