### PR TITLE
Remove Docker deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
   - make test
   - make docker-test
 before_deploy:
-  - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 make
   - make cross-build
   - make dist
 deploy:
@@ -25,18 +24,6 @@ deploy:
     api_key: $GITHUB_TOKEN
     file_glob: true
     file: 'dist/*.{tar.gz,zip}'
-    on:
-      tags: true
-      go: '1.7'
-  - provider: script
-    skip_cleanup: true
-    script: make ci-docker-release
-    on:
-      branch: master
-      go: '1.7'
-  - provider: script
-    skip_cleanup: true
-    script: DOCKER_IMAGE_TAG=$TRAVIS_TAG make ci-docker-release
     on:
       tags: true
       go: '1.7'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 RUN apk add --no-cache --update ca-certificates
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@ LDFLAGS := -ldflags="-s -w -X \"github.com/dtan4/k8sec/version.Version=$(VERSION
 
 DIST_DIRS := find * -type d -exec
 
-DOCKER_REPOSITORY := quay.io
-DOCKER_IMAGE_NAME := $(DOCKER_REPOSITORY)/dtan4/k8sec
+DOCKER_IMAGE_NAME := k8sec
 DOCKER_IMAGE_TAG  ?= latest
 DOCKER_IMAGE      := $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
 
@@ -16,11 +15,6 @@ DOCKER_IMAGE      := $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
 
 bin/$(NAME): $(SRCS)
 	go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o bin/$(NAME)
-
-.PHONY: ci-docker-release
-ci-docker-release: docker-build
-	@docker login -e="$(DOCKER_QUAY_EMAIL)" -u="$(DOCKER_QUAY_USERNAME)" -p="$(DOCKER_QUAY_PASSWORD)" $(DOCKER_REPOSITORY)
-	docker push $(DOCKER_IMAGE)
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ $ make deps
 $ make install
 ```
 
+### Docker image
+
+Docker image is available at [`quay.io/wantedly/k8sec`](https://quay.io/repository/dtan4/k8sec). This image is maintained at https://github.com/dtan4/dockerfile-k8sec .
+
 ## Usage
 
 ### `k8sec list`


### PR DESCRIPTION
## WHY

Now `make cross-build` runs 3 times, at every time of deployments, thor cross-build is NOT required for Docker image deployment.

## WHAT

Disable Docker image deployment. Docker image is remained for local development.

From now on, `quay.io/wantedly/k8sec` Docker image is maintained at https://github.com/dtan4/dockerfile-k8sec.