### PR TITLE
Select context and use kubecfg namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DOCKER_IMAGE      := $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
 .DEFAULT_GOAL := bin/$(NAME)
 
 bin/$(NAME): $(SRCS)
-	go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o bin/$(NAME)
+	go build $(LDFLAGS) -o bin/$(NAME)
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -39,12 +39,21 @@ Docker image is available at [`quay.io/wantedly/k8sec`](https://quay.io/reposito
 
 ## Usage
 
+### Global options
+
+|Option|Description|Required|Default|
+|---------|-----------|-------|-------|
+|`--context=CONTEXT`|Kubernetes context|||
+|`--kubeconfig=KUBECONFIG`|Path of kubeconfig||`~/.kube/config`|
+|`--namespace=NAMESPACE`|Kubernetes namespace||`default`|
+|`-h`, `-help`|Print command line usage|||
+
 ### `k8sec list`
 
 List secrets
 
 ```bash
-$ k8sec list [--base64] [--kubeconfig KUBECONFIG] [--namespace NAMESPACE] [NAME]
+$ k8sec list [--base64] [NAME]
 
 # Example
 $ k8sec list rails
@@ -62,7 +71,7 @@ rails   Opaque  database-url    cG9zdGdyZXM6Ly9leGFtcGxlLmNvbTo1NDMyL2RibmFtZQ==
 Set secrets
 
 ```bash
-$ k8sec set [--base64] [--kubeconfig KUBECONFIG] [--namespace NAMESPACE] NAME KEY1=VALUE1 [KEY2=VALUE2 ...]
+$ k8sec set [--base64] NAME KEY1=VALUE1 [KEY2=VALUE2 ...]
 
 $ k8sec set rails rails-env=production
 rails
@@ -85,7 +94,7 @@ rails   Opaque  foo             "dtan4"
 Unset secrets
 
 ```bash
-$ k8sec unset [--kubeconfig KUBECONFIG] [--namespace NAMESPACE] NAME KEY1 KEY2
+$ k8sec unset NAME KEY1 KEY2...
 
 # Example
 $ k8sec unset rails rails-env
@@ -96,7 +105,7 @@ $ k8sec unset rails rails-env
 Load secrets from dotenv (key=value) format text
 
 ```bash
-$ k8sec load [--kubeconfig KUBECONFIG] [--namespace NAMESPACE] [-f FILENAME] NAME
+$ k8sec load [-f FILENAME] NAME
 
 # Example
 $ cat .env
@@ -112,7 +121,7 @@ $ cat .env | k8sec load rails
 Dump secrets as dotenv (key=value) format
 
 ```bash
-$ k8sec dump [--kubeconfig KUBECONFIG] [--namespace NAMESPACE] [-f FILENAME] [NAME]
+$ k8sec dump [-f FILENAME] [NAME]
 
 # Example
 $ k8sec dump rails

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -9,7 +9,6 @@ import (
 	"github.com/dtan4/k8sec/k8s"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/pkg/api/v1"
 )
 
 var dumpOpts = struct {
@@ -56,7 +55,7 @@ func doDump(cmd *cobra.Command, args []string) error {
 			lines = append(lines, key+"="+strconv.Quote(string(value)))
 		}
 	} else {
-		secrets, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).List(v1.ListOptions{})
+		secrets, err := k8sclient.ListSecrets()
 		if err != nil {
 			return errors.Wrap(err, "Failed to list secret.")
 		}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -39,7 +39,7 @@ func doDump(cmd *cobra.Command, args []string) error {
 		return errors.New("Too many arguments.")
 	}
 
-	clientset, err := k8s.NewKubeClient(rootOpts.kubeconfig)
+	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context, rootOpts.namespace)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}
@@ -47,7 +47,7 @@ func doDump(cmd *cobra.Command, args []string) error {
 	var lines []string
 
 	if len(args) == 1 {
-		secret, err := clientset.Core().Secrets(rootOpts.namespace).Get(args[0])
+		secret, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Get(args[0])
 		if err != nil {
 			return errors.Wrapf(err, "Failed to get secret. name=%s", args[0])
 		}
@@ -56,7 +56,7 @@ func doDump(cmd *cobra.Command, args []string) error {
 			lines = append(lines, key+"="+strconv.Quote(string(value)))
 		}
 	} else {
-		secrets, err := clientset.Core().Secrets(rootOpts.namespace).List(v1.ListOptions{})
+		secrets, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).List(v1.ListOptions{})
 		if err != nil {
 			return errors.Wrap(err, "Failed to list secret.")
 		}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -46,7 +46,7 @@ func doDump(cmd *cobra.Command, args []string) error {
 	var lines []string
 
 	if len(args) == 1 {
-		secret, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Get(args[0])
+		secret, err := k8sclient.GetSecret(args[0])
 		if err != nil {
 			return errors.Wrapf(err, "Failed to get secret. name=%s", args[0])
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dtan4/k8sec/k8s"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/pkg/api/v1"
 )
 
 var listOpts = struct {
@@ -69,7 +68,7 @@ func doList(cmd *cobra.Command, args []string) error {
 			fmt.Fprintln(w, strings.Join([]string{secret.Name, string(secret.Type), key, v}, "\t"))
 		}
 	} else {
-		secrets, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).List(v1.ListOptions{})
+		secrets, err := k8sclient.ListSecrets()
 		if err != nil {
 			return errors.Wrap(err, "Failed to retrieve secrets.")
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -53,7 +53,7 @@ func doList(cmd *cobra.Command, args []string) error {
 	var v string
 
 	if len(args) == 1 {
-		secret, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Get(args[0])
+		secret, err := k8sclient.GetSecret(args[0])
 		if err != nil {
 			return errors.Wrap(err, "Failed to retrieve secrets.")
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -42,7 +42,7 @@ func doList(cmd *cobra.Command, args []string) error {
 		return errors.New("Too many arguments.")
 	}
 
-	clientset, err := k8s.NewKubeClient(rootOpts.kubeconfig)
+	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context, rootOpts.namespace)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}
@@ -54,7 +54,7 @@ func doList(cmd *cobra.Command, args []string) error {
 	var v string
 
 	if len(args) == 1 {
-		secret, err := clientset.Core().Secrets(rootOpts.namespace).Get(args[0])
+		secret, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Get(args[0])
 		if err != nil {
 			return errors.Wrap(err, "Failed to retrieve secrets.")
 		}
@@ -69,7 +69,7 @@ func doList(cmd *cobra.Command, args []string) error {
 			fmt.Fprintln(w, strings.Join([]string{secret.Name, string(secret.Type), key, v}, "\t"))
 		}
 	} else {
-		secrets, err := clientset.Core().Secrets(rootOpts.namespace).List(v1.ListOptions{})
+		secrets, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).List(v1.ListOptions{})
 		if err != nil {
 			return errors.Wrap(err, "Failed to retrieve secrets.")
 		}

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -72,12 +72,12 @@ func doLoad(cmd *cobra.Command, args []string) error {
 		data[k] = []byte(_v)
 	}
 
-	clientset, err := k8s.NewKubeClient(rootOpts.kubeconfig)
+	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context, rootOpts.namespace)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}
 
-	s, err := clientset.Core().Secrets(rootOpts.namespace).Get(name)
+	s, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Get(name)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get secret. name=%s", name)
 	}
@@ -86,7 +86,7 @@ func doLoad(cmd *cobra.Command, args []string) error {
 		s.Data[k] = v
 	}
 
-	_, err = clientset.Core().Secrets(rootOpts.namespace).Update(s)
+	_, err = k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Update(s)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to set secret. name=%s", name)
 	}

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -77,7 +77,7 @@ func doLoad(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}
 
-	s, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Get(name)
+	s, err := k8sclient.GetSecret(name)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get secret. name=%s", name)
 	}

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -86,7 +86,7 @@ func doLoad(cmd *cobra.Command, args []string) error {
 		s.Data[k] = v
 	}
 
-	_, err = k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Update(s)
+	_, err = k8sclient.UpdateSecret(s)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to set secret. name=%s", name)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 )
 
 var rootOpts = struct {
+	context    string
 	debug      bool
 	kubeconfig string
 	namespace  string
@@ -40,9 +41,10 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
+	RootCmd.PersistentFlags().StringVar(&rootOpts.context, "context", "", "Kubernetes context")
 	RootCmd.PersistentFlags().BoolVar(&rootOpts.debug, "debug", false, "Debug mode")
-	RootCmd.PersistentFlags().StringVar(&rootOpts.kubeconfig, "kubeconfig", "", "Path of kubeconfig file")
-	RootCmd.PersistentFlags().StringVar(&rootOpts.namespace, "namespace", "", "Namespace scope")
+	RootCmd.PersistentFlags().StringVar(&rootOpts.kubeconfig, "kubeconfig", "", "Path of kubeconfig")
+	RootCmd.PersistentFlags().StringVar(&rootOpts.namespace, "namespace", "", "Kubernetes namespace")
 }
 
 func initConfig() {

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -72,12 +72,12 @@ func doSet(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	clientset, err := k8s.NewKubeClient(rootOpts.kubeconfig)
+	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context, rootOpts.namespace)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}
 
-	ss, err := clientset.Core().Secrets(rootOpts.namespace).List(v1.ListOptions{})
+	ss, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).List(v1.ListOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get current secret. name=%s", name)
 	}
@@ -94,7 +94,7 @@ func doSet(cmd *cobra.Command, args []string) error {
 	var s *v1.Secret
 
 	if exists {
-		s, err = clientset.Core().Secrets(rootOpts.namespace).Get(name)
+		s, err = k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Get(name)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to get current secret. name=%s", name)
 		}
@@ -107,7 +107,7 @@ func doSet(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		_, err = clientset.Core().Secrets(rootOpts.namespace).Update(s)
+		_, err = k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Update(s)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to update secret. name=%s", name)
 		}
@@ -117,7 +117,7 @@ func doSet(cmd *cobra.Command, args []string) error {
 		}
 		s.SetName(name)
 
-		_, err = clientset.Core().Secrets(rootOpts.namespace).Create(s)
+		_, err = k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Create(s)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to create secret. name=%s", name)
 		}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -94,7 +94,7 @@ func doSet(cmd *cobra.Command, args []string) error {
 	var s *v1.Secret
 
 	if exists {
-		s, err = k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Get(name)
+		s, err = k8sclient.GetSecret(name)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to get current secret. name=%s", name)
 		}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -107,7 +107,7 @@ func doSet(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		_, err = k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Update(s)
+		_, err = k8sclient.UpdateSecret(s)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to update secret. name=%s", name)
 		}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -117,7 +117,7 @@ func doSet(cmd *cobra.Command, args []string) error {
 		}
 		s.SetName(name)
 
-		_, err = k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Create(s)
+		_, err = k8sclient.CreateSecret(s)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to create secret. name=%s", name)
 		}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -77,7 +77,7 @@ func doSet(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}
 
-	ss, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).List(v1.ListOptions{})
+	ss, err := k8sclient.ListSecrets()
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get current secret. name=%s", name)
 	}

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -26,7 +26,7 @@ func doUnset(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}
 
-	s, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Get(name)
+	s, err := k8sclient.GetSecret(name)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get current secret. name=%s", name)
 	}

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -21,12 +21,12 @@ func doUnset(cmd *cobra.Command, args []string) error {
 	}
 	name := args[0]
 
-	clientset, err := k8s.NewKubeClient(rootOpts.kubeconfig)
+	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context, rootOpts.namespace)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}
 
-	s, err := clientset.Core().Secrets(rootOpts.namespace).Get(name)
+	s, err := k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Get(name)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get current secret. name=%s", name)
 	}
@@ -40,7 +40,7 @@ func doUnset(cmd *cobra.Command, args []string) error {
 		delete(s.Data, k)
 	}
 
-	_, err = clientset.Core().Secrets(rootOpts.namespace).Update(s)
+	_, err = k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Update(s)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to unset secret. name=%s", name)
 	}

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -40,7 +40,7 @@ func doUnset(cmd *cobra.Command, args []string) error {
 		delete(s.Data, k)
 	}
 
-	_, err = k8sclient.Clientset.Core().Secrets(k8sclient.Namespace).Update(s)
+	_, err = k8sclient.UpdateSecret(s)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to unset secret. name=%s", name)
 	}

--- a/k8s/kubeclient.go
+++ b/k8s/kubeclient.go
@@ -63,3 +63,8 @@ func (c *KubeClient) GetSecret(name string) (*v1.Secret, error) {
 func (c *KubeClient) ListSecrets() (*v1.SecretList, error) {
 	return c.Clientset.Core().Secrets(c.Namespace).List(v1.ListOptions{})
 }
+
+// UpdateSecret updates the existed secret
+func (c *KubeClient) UpdateSecret(secret *v1.Secret) (*v1.Secret, error) {
+	return c.Clientset.Core().Secrets(c.Namespace).Update(secret)
+}

--- a/k8s/kubeclient.go
+++ b/k8s/kubeclient.go
@@ -53,3 +53,8 @@ func NewKubeClient(kubeconfig, context, namespace string) (*KubeClient, error) {
 		Namespace: namespace,
 	}, nil
 }
+
+// ListSecrets returns the list of Secrets
+func (c *KubeClient) ListSecrets() (*v1.SecretList, error) {
+	return c.Clientset.Core().Secrets(c.Namespace).List(v1.ListOptions{})
+}

--- a/k8s/kubeclient.go
+++ b/k8s/kubeclient.go
@@ -54,6 +54,11 @@ func NewKubeClient(kubeconfig, context, namespace string) (*KubeClient, error) {
 	}, nil
 }
 
+// CreateSecret creates new Secret
+func (c *KubeClient) CreateSecret(secret *v1.Secret) (*v1.Secret, error) {
+	return c.Clientset.Core().Secrets(c.Namespace).Create(secret)
+}
+
 // GetSecret returns secret with the given name
 func (c *KubeClient) GetSecret(name string) (*v1.Secret, error) {
 	return c.Clientset.Core().Secrets(c.Namespace).Get(name)

--- a/k8s/kubeclient.go
+++ b/k8s/kubeclient.go
@@ -54,6 +54,11 @@ func NewKubeClient(kubeconfig, context, namespace string) (*KubeClient, error) {
 	}, nil
 }
 
+// GetSecret returns secret with the given name
+func (c *KubeClient) GetSecret(name string) (*v1.Secret, error) {
+	return c.Clientset.Core().Secrets(c.Namespace).Get(name)
+}
+
 // ListSecrets returns the list of Secrets
 func (c *KubeClient) ListSecrets() (*v1.SecretList, error) {
 	return c.Clientset.Core().Secrets(c.Namespace).List(v1.ListOptions{})

--- a/k8s/kubeclient.go
+++ b/k8s/kubeclient.go
@@ -8,8 +8,8 @@ import (
 
 // KubeClient represents Kubernetes client and calculated namespace
 type KubeClient struct {
-	Clientset *kubernetes.Clientset
-	Namespace string
+	clientset *kubernetes.Clientset
+	namespace string
 }
 
 // NewKubeClient creates new Kubernetes API client
@@ -49,27 +49,27 @@ func NewKubeClient(kubeconfig, context, namespace string) (*KubeClient, error) {
 	}
 
 	return &KubeClient{
-		Clientset: clientset,
-		Namespace: namespace,
+		clientset: clientset,
+		namespace: namespace,
 	}, nil
 }
 
 // CreateSecret creates new Secret
 func (c *KubeClient) CreateSecret(secret *v1.Secret) (*v1.Secret, error) {
-	return c.Clientset.Core().Secrets(c.Namespace).Create(secret)
+	return c.clientset.Core().Secrets(c.namespace).Create(secret)
 }
 
 // GetSecret returns secret with the given name
 func (c *KubeClient) GetSecret(name string) (*v1.Secret, error) {
-	return c.Clientset.Core().Secrets(c.Namespace).Get(name)
+	return c.clientset.Core().Secrets(c.namespace).Get(name)
 }
 
 // ListSecrets returns the list of Secrets
 func (c *KubeClient) ListSecrets() (*v1.SecretList, error) {
-	return c.Clientset.Core().Secrets(c.Namespace).List(v1.ListOptions{})
+	return c.clientset.Core().Secrets(c.namespace).List(v1.ListOptions{})
 }
 
 // UpdateSecret updates the existed secret
 func (c *KubeClient) UpdateSecret(secret *v1.Secret) (*v1.Secret, error) {
-	return c.Clientset.Core().Secrets(c.Namespace).Update(secret)
+	return c.clientset.Core().Secrets(c.namespace).Update(secret)
 }


### PR DESCRIPTION
## WHY

Now `--namespace` flag is required in fact, because Kubernetes (or its client) refuses empty namespace.

## WHAT

Use `default` namespace or namespace stored in kubecfg in default.

## REF

- https://github.com/dtan4/k8stail/pull/13
- https://github.com/dtan4/k8stail/pull/21