### PR TITLE
Add -n flag as an alias of --namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Docker image is available at [`quay.io/wantedly/k8sec`](https://quay.io/reposito
 |---------|-----------|-------|-------|
 |`--context=CONTEXT`|Kubernetes context|||
 |`--kubeconfig=KUBECONFIG`|Path of kubeconfig||`~/.kube/config`|
-|`--namespace=NAMESPACE`|Kubernetes namespace||`default`|
+|`-n`, --namespace=NAMESPACE`|Kubernetes namespace||`default`|
 |`-h`, `-help`|Print command line usage|||
 
 ### `k8sec list`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,7 +44,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&rootOpts.context, "context", "", "Kubernetes context")
 	RootCmd.PersistentFlags().BoolVar(&rootOpts.debug, "debug", false, "Debug mode")
 	RootCmd.PersistentFlags().StringVar(&rootOpts.kubeconfig, "kubeconfig", "", "Path of kubeconfig")
-	RootCmd.PersistentFlags().StringVar(&rootOpts.namespace, "namespace", "", "Kubernetes namespace")
+	RootCmd.PersistentFlags().StringVarP(&rootOpts.namespace, "namespace", "n", "", "Kubernetes namespace")
 }
 
 func initConfig() {


### PR DESCRIPTION
`kubectl` has the flag `-n` as an alias of `--namespace`. k8sec should have the same flag for usability too.

```sh-session
$ kubectl options | grep namespace
  -n, --namespace='': If present, the namespace scope for this CLI request
```