### PR TITLE
Exclude namespace from kubeclient

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -49,9 +49,17 @@ func doList(cmd *cobra.Command, args []string) error {
 		return errors.New("Too many arguments.")
 	}
 
-	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context, rootOpts.namespace)
+	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
+	}
+
+	var namespace string
+
+	if rootOpts.namespace != "" {
+		namespace = rootOpts.namespace
+	} else {
+		namespace = k8sclient.DefaultNamespace()
 	}
 
 	w := new(tabwriter.Writer)
@@ -63,7 +71,7 @@ func doList(cmd *cobra.Command, args []string) error {
 	secrets := []Secret{}
 
 	if len(args) == 1 {
-		secret, err := k8sclient.GetSecret(args[0])
+		secret, err := k8sclient.GetSecret(namespace, args[0])
 		if err != nil {
 			return errors.Wrap(err, "Failed to retrieve secrets.")
 		}
@@ -88,7 +96,7 @@ func doList(cmd *cobra.Command, args []string) error {
 			return secrets[i].Key < secrets[j].Key
 		})
 	} else {
-		ss, err := k8sclient.ListSecrets()
+		ss, err := k8sclient.ListSecrets(namespace)
 		if err != nil {
 			return errors.Wrap(err, "Failed to retrieve secrets.")
 		}

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -72,12 +72,20 @@ func doLoad(cmd *cobra.Command, args []string) error {
 		data[k] = []byte(_v)
 	}
 
-	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context, rootOpts.namespace)
+	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}
 
-	s, err := k8sclient.GetSecret(name)
+	var namespace string
+
+	if rootOpts.namespace != "" {
+		namespace = rootOpts.namespace
+	} else {
+		namespace = k8sclient.DefaultNamespace()
+	}
+
+	s, err := k8sclient.GetSecret(namespace, name)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get secret. name=%s", name)
 	}
@@ -86,7 +94,7 @@ func doLoad(cmd *cobra.Command, args []string) error {
 		s.Data[k] = v
 	}
 
-	_, err = k8sclient.UpdateSecret(s)
+	_, err = k8sclient.UpdateSecret(namespace, s)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to set secret. name=%s", name)
 	}

--- a/k8s/kubeclient.go
+++ b/k8s/kubeclient.go
@@ -4,16 +4,17 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 // KubeClient represents Kubernetes client and calculated namespace
 type KubeClient struct {
 	clientset *kubernetes.Clientset
-	namespace string
+	rawConfig api.Config
 }
 
 // NewKubeClient creates new Kubernetes API client
-func NewKubeClient(kubeconfig, context, namespace string) (*KubeClient, error) {
+func NewKubeClient(kubeconfig, context string) (*KubeClient, error) {
 	if kubeconfig == "" {
 		kubeconfig = clientcmd.RecommendedHomeFile
 	}
@@ -38,38 +39,41 @@ func NewKubeClient(kubeconfig, context, namespace string) (*KubeClient, error) {
 		return nil, err
 	}
 
-	ns := namespace
-
-	if ns == "" {
-		if rawConfig.Contexts[rawConfig.CurrentContext].Namespace == "" {
-			ns = v1.NamespaceDefault
-		} else {
-			ns = rawConfig.Contexts[rawConfig.CurrentContext].Namespace
-		}
-	}
-
 	return &KubeClient{
 		clientset: clientset,
-		namespace: ns,
+		rawConfig: rawConfig,
 	}, nil
 }
 
+// DefaultNamespace returns the default namespace in kubeconfig
+func (c *KubeClient) DefaultNamespace() string {
+	var namespace string
+
+	if c.rawConfig.Contexts[c.rawConfig.CurrentContext].Namespace == "" {
+		namespace = v1.NamespaceDefault
+	} else {
+		namespace = c.rawConfig.Contexts[c.rawConfig.CurrentContext].Namespace
+	}
+
+	return namespace
+}
+
 // CreateSecret creates new Secret
-func (c *KubeClient) CreateSecret(secret *v1.Secret) (*v1.Secret, error) {
-	return c.clientset.Core().Secrets(c.namespace).Create(secret)
+func (c *KubeClient) CreateSecret(namespace string, secret *v1.Secret) (*v1.Secret, error) {
+	return c.clientset.Core().Secrets(namespace).Create(secret)
 }
 
 // GetSecret returns secret with the given name
-func (c *KubeClient) GetSecret(name string) (*v1.Secret, error) {
-	return c.clientset.Core().Secrets(c.namespace).Get(name)
+func (c *KubeClient) GetSecret(namespace, name string) (*v1.Secret, error) {
+	return c.clientset.Core().Secrets(namespace).Get(name)
 }
 
 // ListSecrets returns the list of Secrets
-func (c *KubeClient) ListSecrets() (*v1.SecretList, error) {
-	return c.clientset.Core().Secrets(c.namespace).List(v1.ListOptions{})
+func (c *KubeClient) ListSecrets(namespace string) (*v1.SecretList, error) {
+	return c.clientset.Core().Secrets(namespace).List(v1.ListOptions{})
 }
 
 // UpdateSecret updates the existed secret
-func (c *KubeClient) UpdateSecret(secret *v1.Secret) (*v1.Secret, error) {
-	return c.clientset.Core().Secrets(c.namespace).Update(secret)
+func (c *KubeClient) UpdateSecret(namespace string, secret *v1.Secret) (*v1.Secret, error) {
+	return c.clientset.Core().Secrets(namespace).Update(secret)
 }


### PR DESCRIPTION
To implement inter-namespaces feature, including namespace in k8s client is incovenient.