### PR TITLE
Rename client package and struct

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-package k8s
+package client
 
 import (
 	"k8s.io/api/core/v1"

--- a/client/client.go
+++ b/client/client.go
@@ -9,14 +9,14 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
-// KubeClient represents Kubernetes client and calculated namespace
-type KubeClient struct {
+// Client represents Kubernetes client and calculated namespace
+type Client struct {
 	clientset kubernetes.Interface
 	rawConfig api.Config
 }
 
 // New creates new Kubernetes API client
-func New(kubeconfig, context string) (*KubeClient, error) {
+func New(kubeconfig, context string) (*Client, error) {
 	if kubeconfig == "" {
 		kubeconfig = clientcmd.RecommendedHomeFile
 	}
@@ -41,14 +41,14 @@ func New(kubeconfig, context string) (*KubeClient, error) {
 		return nil, err
 	}
 
-	return &KubeClient{
+	return &Client{
 		clientset: clientset,
 		rawConfig: rawConfig,
 	}, nil
 }
 
 // DefaultNamespace returns the default namespace in kubeconfig
-func (c *KubeClient) DefaultNamespace() string {
+func (c *Client) DefaultNamespace() string {
 	var namespace string
 
 	if c.rawConfig.Contexts[c.rawConfig.CurrentContext].Namespace == "" {
@@ -61,21 +61,21 @@ func (c *KubeClient) DefaultNamespace() string {
 }
 
 // CreateSecret creates new Secret
-func (c *KubeClient) CreateSecret(namespace string, secret *v1.Secret) (*v1.Secret, error) {
+func (c *Client) CreateSecret(namespace string, secret *v1.Secret) (*v1.Secret, error) {
 	return c.clientset.Core().Secrets(namespace).Create(secret)
 }
 
 // GetSecret returns secret with the given name
-func (c *KubeClient) GetSecret(namespace, name string) (*v1.Secret, error) {
+func (c *Client) GetSecret(namespace, name string) (*v1.Secret, error) {
 	return c.clientset.Core().Secrets(namespace).Get(name, metav1.GetOptions{})
 }
 
 // ListSecrets returns the list of Secrets
-func (c *KubeClient) ListSecrets(namespace string) (*v1.SecretList, error) {
+func (c *Client) ListSecrets(namespace string) (*v1.SecretList, error) {
 	return c.clientset.Core().Secrets(namespace).List(metav1.ListOptions{})
 }
 
 // UpdateSecret updates the existed secret
-func (c *KubeClient) UpdateSecret(namespace string, secret *v1.Secret) (*v1.Secret, error) {
+func (c *Client) UpdateSecret(namespace string, secret *v1.Secret) (*v1.Secret, error) {
 	return c.clientset.Core().Secrets(namespace).Update(secret)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -15,8 +15,8 @@ type KubeClient struct {
 	rawConfig api.Config
 }
 
-// NewKubeClient creates new Kubernetes API client
-func NewKubeClient(kubeconfig, context string) (*KubeClient, error) {
+// New creates new Kubernetes API client
+func New(kubeconfig, context string) (*KubeClient, error) {
 	if kubeconfig == "" {
 		kubeconfig = clientcmd.RecommendedHomeFile
 	}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/dtan4/k8sec/k8s"
+	"github.com/dtan4/k8sec/client"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -38,7 +38,7 @@ func doDump(cmd *cobra.Command, args []string) error {
 		return errors.New("Too many arguments.")
 	}
 
-	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
+	k8sclient, err := client.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -38,7 +38,7 @@ func doDump(cmd *cobra.Command, args []string) error {
 		return errors.New("Too many arguments.")
 	}
 
-	k8sclient, err := client.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
+	k8sclient, err := client.New(rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/dtan4/k8sec/k8s"
+	"github.com/dtan4/k8sec/client"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -49,7 +49,7 @@ func doList(cmd *cobra.Command, args []string) error {
 		return errors.New("Too many arguments.")
 	}
 
-	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
+	k8sclient, err := client.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -49,7 +49,7 @@ func doList(cmd *cobra.Command, args []string) error {
 		return errors.New("Too many arguments.")
 	}
 
-	k8sclient, err := client.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
+	k8sclient, err := client.New(rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dtan4/k8sec/k8s"
+	"github.com/dtan4/k8sec/client"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -72,7 +72,7 @@ func doLoad(cmd *cobra.Command, args []string) error {
 		data[k] = []byte(_v)
 	}
 
-	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
+	k8sclient, err := client.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -72,7 +72,7 @@ func doLoad(cmd *cobra.Command, args []string) error {
 		data[k] = []byte(_v)
 	}
 
-	k8sclient, err := client.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
+	k8sclient, err := client.New(rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -72,7 +72,7 @@ func doSet(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	k8sclient, err := client.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
+	k8sclient, err := client.New(rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dtan4/k8sec/k8s"
+	"github.com/dtan4/k8sec/client"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
@@ -72,7 +72,7 @@ func doSet(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
+	k8sclient, err := client.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/dtan4/k8sec/k8s"
+	"github.com/dtan4/k8sec/client"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +21,7 @@ func doUnset(cmd *cobra.Command, args []string) error {
 	}
 	name := args[0]
 
-	k8sclient, err := k8s.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
+	k8sclient, err := client.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -21,7 +21,7 @@ func doUnset(cmd *cobra.Command, args []string) error {
 	}
 	name := args[0]
 
-	k8sclient, err := client.NewKubeClient(rootOpts.kubeconfig, rootOpts.context)
+	k8sclient, err := client.New(rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize Kubernetes API client.")
 	}

--- a/k8s/kubeclient.go
+++ b/k8s/kubeclient.go
@@ -11,7 +11,7 @@ import (
 
 // KubeClient represents Kubernetes client and calculated namespace
 type KubeClient struct {
-	clientset *kubernetes.Clientset
+	clientset kubernetes.Interface
 	rawConfig api.Config
 }
 


### PR DESCRIPTION
The name `k8s.KubeClient` is redundant. There is only one "client" in this tool, so just using `client` is enough.

Additionally, `clientset` will be used for testing purpose.