### PR TITLE
Use Go 1.14 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
   directories:
     - vendor
 go:
-  - '1.10.3'
+  - '1.14'
 before_install:
   - sudo add-apt-repository ppa:masterminds/glide -y
   - sudo apt-get update -q


### PR DESCRIPTION
as a preparation to migrate Glide to Go Modules