### PR TITLE
Refactor rootCmd

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -126,8 +126,6 @@ func runDump(ctx context.Context, k8sclient client.Client, namespace string, arg
 }
 
 func init() {
-	RootCmd.AddCommand(dumpCmd)
-
 	dumpCmd.Flags().StringVarP(&dumpOpts.filename, "filename", "f", "", "File to dump")
 	dumpCmd.Flags().BoolVar(&dumpOpts.noquotes, "noquotes", false, "Dump without quotes")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -153,7 +153,5 @@ func runList(ctx context.Context, k8sclient client.Client, namespace string, arg
 }
 
 func init() {
-	RootCmd.AddCommand(listCmd)
-
 	listCmd.Flags().BoolVar(&listOpts.base64encode, "base64", false, "Show values as base64-encoded string")
 }

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -113,7 +113,5 @@ func runLoad(ctx context.Context, k8sclient client.Client, namespace string, arg
 }
 
 func init() {
-	RootCmd.AddCommand(loadCmd)
-
 	loadCmd.Flags().StringVarP(&loadOpts.filename, "filename", "f", "", "File to load")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,21 +14,42 @@ var rootOpts = struct {
 	namespace  string
 }{}
 
-// RootCmd represents the base command when called without any subcommands
-var RootCmd = &cobra.Command{
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	Use:           "k8sec",
-	Short:         "CLI tool to manage Kubernetes Secrets easily",
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	//	Run: func(cmd *cobra.Command, args []string) { },
+func newRootCmd(args []string) *cobra.Command {
+	cmd := &cobra.Command{
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Use:           "k8sec",
+		Short:         "CLI tool to manage Kubernetes Secrets easily",
+		// Uncomment the following line if your bare application
+		// has an action associated with it:
+		//	Run: func(cmd *cobra.Command, args []string) { },
+	}
+
+	flags := cmd.PersistentFlags()
+
+	flags.StringVar(&rootOpts.context, "context", "", "Kubernetes context")
+	flags.BoolVar(&rootOpts.debug, "debug", false, "Debug mode")
+	flags.StringVar(&rootOpts.kubeconfig, "kubeconfig", "", "Path of kubeconfig")
+	flags.StringVarP(&rootOpts.namespace, "namespace", "n", "", "Kubernetes namespace")
+
+	flags.Parse(args)
+
+	cmd.AddCommand(dumpCmd)
+	cmd.AddCommand(listCmd)
+	cmd.AddCommand(loadCmd)
+	cmd.AddCommand(setCmd)
+	cmd.AddCommand(unsetCmd)
+	cmd.AddCommand(versionCmd)
+
+	return cmd
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+func Execute(args []string) {
+	cmd := newRootCmd(args)
+
+	if err := cmd.Execute(); err != nil {
 		if rootOpts.debug {
 			fmt.Printf("%+v\n", err)
 		} else {
@@ -36,16 +57,4 @@ func Execute() {
 		}
 		os.Exit(-1)
 	}
-}
-
-func init() {
-	cobra.OnInitialize(initConfig)
-
-	RootCmd.PersistentFlags().StringVar(&rootOpts.context, "context", "", "Kubernetes context")
-	RootCmd.PersistentFlags().BoolVar(&rootOpts.debug, "debug", false, "Debug mode")
-	RootCmd.PersistentFlags().StringVar(&rootOpts.kubeconfig, "kubeconfig", "", "Path of kubeconfig")
-	RootCmd.PersistentFlags().StringVarP(&rootOpts.namespace, "namespace", "n", "", "Kubernetes namespace")
-}
-
-func initConfig() {
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -14,7 +15,7 @@ var rootOpts = struct {
 	namespace  string
 }{}
 
-func newRootCmd(args []string) *cobra.Command {
+func newRootCmd(out io.Writer, args []string) *cobra.Command {
 	cmd := &cobra.Command{
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -46,8 +47,8 @@ func newRootCmd(args []string) *cobra.Command {
 
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute(args []string) {
-	cmd := newRootCmd(args)
+func Execute(out io.Writer, args []string) {
+	cmd := newRootCmd(out, args)
 
 	if err := cmd.Execute(); err != nil {
 		if rootOpts.debug {

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -145,7 +145,5 @@ func runSet(ctx context.Context, k8sclient client.Client, namespace string, args
 }
 
 func init() {
-	RootCmd.AddCommand(setCmd)
-
 	setCmd.Flags().BoolVar(&setOpts.base64encoded, "base64", false, "Decode the given value as base64-encoded string")
 }

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -67,5 +67,4 @@ func runUnset(ctx context.Context, k8sclient client.Client, namespace string, ar
 }
 
 func init() {
-	RootCmd.AddCommand(unsetCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,5 +19,4 @@ func doVersion(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RootCmd.AddCommand(versionCmd)
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,11 @@
 package main
 
-import "github.com/dtan4/k8sec/cmd"
+import (
+	"os"
+
+	"github.com/dtan4/k8sec/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	cmd.Execute(os.Args)
 }

--- a/main.go
+++ b/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	cmd.Execute(os.Args)
+	cmd.Execute(os.Stdout, os.Args)
 }


### PR DESCRIPTION
## WHAT

Refactor `rootCmd`

- Generate `rootCmd` from constructor instead of using it as global variable
- Stop using `init` for `rootCmd`

## REF

https://github.com/helm/helm/blob/fc9b46067f8f24a90b52eba31e09b31e69011e93/cmd/helm/root.go#L159