### PR TITLE
Refactor load command

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -13,11 +13,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var loadOpts = struct {
+type loadOpts struct {
 	filename string
-}{}
+}
 
 func newLoadCmd(out io.Writer) *cobra.Command {
+	opts := loadOpts{}
+
 	loadCmd := &cobra.Command{
 		Use:   "load NAME",
 		Short: "Load secrets from dotenv (key=value) format text",
@@ -51,16 +53,16 @@ $ cat .env | k8sec load rails
 				namespace = k8sclient.DefaultNamespace()
 			}
 
-			return runLoad(ctx, k8sclient, namespace, args, os.Stdin, os.Stdout)
+			return runLoad(ctx, k8sclient, namespace, args, os.Stdin, os.Stdout, &opts)
 		},
 	}
 
-	loadCmd.Flags().StringVarP(&loadOpts.filename, "filename", "f", "", "File to load")
+	loadCmd.Flags().StringVarP(&opts.filename, "filename", "f", "", "File to load")
 
 	return loadCmd
 }
 
-func runLoad(ctx context.Context, k8sclient client.Client, namespace string, args []string, in io.Reader, out io.Writer) error {
+func runLoad(ctx context.Context, k8sclient client.Client, namespace string, args []string, in io.Reader, out io.Writer, opts *loadOpts) error {
 	if len(args) != 1 {
 		return errors.New("Variable name must be specified.")
 	}
@@ -69,10 +71,10 @@ func runLoad(ctx context.Context, k8sclient client.Client, namespace string, arg
 	var sc *bufio.Scanner
 	data := map[string][]byte{}
 
-	if loadOpts.filename != "" {
-		f, err := os.Open(loadOpts.filename)
+	if opts.filename != "" {
+		f, err := os.Open(opts.filename)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to open file. filename=%s", loadOpts.filename)
+			return errors.Wrapf(err, "Failed to open file. filename=%s", opts.filename)
 		}
 		defer f.Close()
 

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -17,7 +17,7 @@ type loadOpts struct {
 	filename string
 }
 
-func newLoadCmd(out io.Writer) *cobra.Command {
+func newLoadCmd(in io.Reader, out io.Writer) *cobra.Command {
 	opts := loadOpts{}
 
 	loadCmd := &cobra.Command{
@@ -53,7 +53,7 @@ $ cat .env | k8sec load rails
 				namespace = k8sclient.DefaultNamespace()
 			}
 
-			return runLoad(ctx, k8sclient, namespace, args, os.Stdin, os.Stdout, &opts)
+			return runLoad(ctx, k8sclient, namespace, args, in, out, &opts)
 		},
 	}
 

--- a/cmd/load_test.go
+++ b/cmd/load_test.go
@@ -78,7 +78,7 @@ rails-env="production"`,
 			in := strings.NewReader(tc.input)
 			var out bytes.Buffer
 
-			err := runLoad(context.Background(), k8sclient, namespace, tc.args, in, &out)
+			err := runLoad(context.Background(), k8sclient, namespace, tc.args, in, &out, &loadOpts{})
 
 			if tc.wantErr != nil {
 				if err == nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ var rootOpts = struct {
 	namespace  string
 }{}
 
-func newRootCmd(out io.Writer, args []string) *cobra.Command {
+func newRootCmd(in io.Reader, out io.Writer, args []string) *cobra.Command {
 	cmd := &cobra.Command{
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -37,7 +37,7 @@ func newRootCmd(out io.Writer, args []string) *cobra.Command {
 
 	cmd.AddCommand(dumpCmd)
 	cmd.AddCommand(listCmd)
-	cmd.AddCommand(newLoadCmd(out))
+	cmd.AddCommand(newLoadCmd(in, out))
 	cmd.AddCommand(newSetCmd(out))
 	cmd.AddCommand(newUnsetCmd(out))
 	cmd.AddCommand(versionCmd)
@@ -47,8 +47,8 @@ func newRootCmd(out io.Writer, args []string) *cobra.Command {
 
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute(out io.Writer, args []string) {
-	cmd := newRootCmd(out, args)
+func Execute(in io.Reader, out io.Writer, args []string) {
+	cmd := newRootCmd(in, out, args)
 
 	if err := cmd.Execute(); err != nil {
 		if rootOpts.debug {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,7 @@ func newRootCmd(out io.Writer, args []string) *cobra.Command {
 
 	cmd.AddCommand(dumpCmd)
 	cmd.AddCommand(listCmd)
-	cmd.AddCommand(loadCmd)
+	cmd.AddCommand(newLoadCmd(out))
 	cmd.AddCommand(newSetCmd(out))
 	cmd.AddCommand(newUnsetCmd(out))
 	cmd.AddCommand(versionCmd)

--- a/main.go
+++ b/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	cmd.Execute(os.Stdout, os.Args)
+	cmd.Execute(os.Stdin, os.Stdout, os.Args)
 }


### PR DESCRIPTION
## WHAT

Refactor `load` command:

- Create `loadCmd` by constructor
- Treat `loadOpts` as local object instead of global object