### PR TITLE
Refactor list command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -15,11 +15,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var listOpts = struct {
+type listOpts struct {
 	base64encode bool
-}{}
+}
 
 func newListCmd(out io.Writer) *cobra.Command {
+	opts := listOpts{}
+
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List secrets",
@@ -55,11 +57,11 @@ rails   Opaque  database-url    cG9zdGdyZXM6Ly9leGFtcGxlLmNvbTo1NDMyL2RibmFtZQ==
 				namespace = k8sclient.DefaultNamespace()
 			}
 
-			return runList(ctx, k8sclient, namespace, args, out)
+			return runList(ctx, k8sclient, namespace, args, out, &opts)
 		},
 	}
 
-	listCmd.Flags().BoolVar(&listOpts.base64encode, "base64", false, "Show values as base64-encoded string")
+	listCmd.Flags().BoolVar(&opts.base64encode, "base64", false, "Show values as base64-encoded string")
 
 	return listCmd
 }
@@ -71,7 +73,7 @@ type Secret struct {
 	Value string
 }
 
-func runList(ctx context.Context, k8sclient client.Client, namespace string, args []string, out io.Writer) error {
+func runList(ctx context.Context, k8sclient client.Client, namespace string, args []string, out io.Writer, opts *listOpts) error {
 	w := new(tabwriter.Writer)
 	w.Init(out, 0, 8, 0, '\t', 0)
 	fmt.Fprintln(w, strings.Join([]string{"NAME", "TYPE", "KEY", "VALUE"}, "\t"))
@@ -87,7 +89,7 @@ func runList(ctx context.Context, k8sclient client.Client, namespace string, arg
 		}
 
 		for key, value := range secret.Data {
-			if listOpts.base64encode {
+			if opts.base64encode {
 				v = base64.StdEncoding.EncodeToString(value)
 			} else {
 				v = strconv.Quote(string(value))
@@ -117,7 +119,7 @@ func runList(ctx context.Context, k8sclient client.Client, namespace string, arg
 			}{}
 
 			for key, value := range secret.Data {
-				if listOpts.base64encode {
+				if opts.base64encode {
 					v = base64.StdEncoding.EncodeToString(value)
 				} else {
 					v = strconv.Quote(string(value))

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -122,8 +122,6 @@ rails	Opaque	rails-env	"production"
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			listOpts.base64encode = tc.base64encode
-
 			k8sclient := &fakeClient{
 				getSecretResponse:   tc.secret,
 				listSecretsResponse: tc.secrets,
@@ -132,7 +130,10 @@ rails	Opaque	rails-env	"production"
 
 			var out bytes.Buffer
 
-			err := runList(context.Background(), k8sclient, namespace, tc.args, &out)
+			opts := listOpts{
+				base64encode: tc.base64encode,
+			}
+			err := runList(context.Background(), k8sclient, namespace, tc.args, &out, &opts)
 
 			if tc.wantErr != nil {
 				if err == nil {

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -86,27 +86,26 @@ rails	Opaque	rails-env	"production"
 			wantErr: nil,
 		},
 
-		// TODO: Uncomment this once I move base64encode to local variable
-		// 		"one secret arg with --base64 option": {
-		// 			base64encode: true,
-		// 			args:         []string{"rails"},
-		// 			secret: &v1.Secret{
-		// 				ObjectMeta: metav1.ObjectMeta{
-		// 					Name: "rails",
-		// 				},
-		// 				Data: map[string][]byte{
-		// 					"rails-env":    []byte("production"),
-		// 					"database-url": []byte("postgres://example.com:5432/dbname"),
-		// 				},
-		// 				Type: v1.SecretTypeOpaque,
-		// 			},
-		// 			err: nil,
-		// 			wantOut: `NAME	TYPE	KEY		VALUE
-		// rails	Opaque	database-url	cG9zdGdyZXM6Ly9leGFtcGxlLmNvbTo1NDMyL2RibmFtZQ==
-		// rails	Opaque	rails-env	cHJvZHVjdGlvbg==
-		// `,
-		// 			wantErr: nil,
-		// 		},
+		"one secret arg with --base64 option": {
+			base64encode: true,
+			args:         []string{"rails"},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rails",
+				},
+				Data: map[string][]byte{
+					"rails-env":    []byte("production"),
+					"database-url": []byte("postgres://example.com:5432/dbname"),
+				},
+				Type: v1.SecretTypeOpaque,
+			},
+			err: nil,
+			wantOut: `NAME	TYPE	KEY		VALUE
+rails	Opaque	database-url	cG9zdGdyZXM6Ly9leGFtcGxlLmNvbTo1NDMyL2RibmFtZQ==
+rails	Opaque	rails-env	cHJvZHVjdGlvbg==
+`,
+			wantErr: nil,
+		},
 
 		"one secret and error": {
 			args:    []string{"rails"},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,7 @@ func newRootCmd(out io.Writer, args []string) *cobra.Command {
 	flags.Parse(args)
 
 	cmd.AddCommand(dumpCmd)
-	cmd.AddCommand(listCmd)
+	cmd.AddCommand(newListCmd(out))
 	cmd.AddCommand(loadCmd)
 	cmd.AddCommand(newSetCmd(out))
 	cmd.AddCommand(newUnsetCmd(out))


### PR DESCRIPTION
## WHAT

Refactor `list` command:

- Create `listCmd` by constructor
- Treat `listOpts` as local object instead of global object
- Uncomment one test case with the above change (now we can use `base64encode` in local scope