### PR TITLE
Refactor dump command

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -62,7 +62,7 @@ database-url=postgres://example.com:5432/dbname
 				namespace = k8sclient.DefaultNamespace()
 			}
 
-			return runDump(ctx, k8sclient, namespace, args, os.Stdout, &opts)
+			return runDump(ctx, k8sclient, namespace, args, out, &opts)
 		},
 	}
 

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -14,12 +14,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var dumpOpts = struct {
+type dumpOpts struct {
 	filename string
 	noquotes bool
-}{}
+}
 
 func newDumpCmd(out io.Writer) *cobra.Command {
+	opts := dumpOpts{}
+
 	dumpCmd := &cobra.Command{
 		Use:   "dump [NAME]",
 		Short: "Dump secrets as dotenv (key=value) format",
@@ -60,17 +62,17 @@ database-url=postgres://example.com:5432/dbname
 				namespace = k8sclient.DefaultNamespace()
 			}
 
-			return runDump(ctx, k8sclient, namespace, args, os.Stdout)
+			return runDump(ctx, k8sclient, namespace, args, os.Stdout, &opts)
 		},
 	}
 
-	dumpCmd.Flags().StringVarP(&dumpOpts.filename, "filename", "f", "", "File to dump")
-	dumpCmd.Flags().BoolVar(&dumpOpts.noquotes, "noquotes", false, "Dump without quotes")
+	dumpCmd.Flags().StringVarP(&opts.filename, "filename", "f", "", "File to dump")
+	dumpCmd.Flags().BoolVar(&opts.noquotes, "noquotes", false, "Dump without quotes")
 
 	return dumpCmd
 }
 
-func runDump(ctx context.Context, k8sclient client.Client, namespace string, args []string, out io.Writer) error {
+func runDump(ctx context.Context, k8sclient client.Client, namespace string, args []string, out io.Writer, opts *dumpOpts) error {
 	var lines []string
 
 	if len(args) == 1 {
@@ -81,7 +83,7 @@ func runDump(ctx context.Context, k8sclient client.Client, namespace string, arg
 
 		for key, value := range secret.Data {
 			line := string(value)
-			if !dumpOpts.noquotes {
+			if !opts.noquotes {
 				line = strconv.Quote(line)
 			}
 			lines = append(lines, key+"="+line)
@@ -95,7 +97,7 @@ func runDump(ctx context.Context, k8sclient client.Client, namespace string, arg
 		for _, secret := range secrets.Items {
 			for key, value := range secret.Data {
 				v := string(value)
-				if !dumpOpts.noquotes {
+				if !opts.noquotes {
 					v = strconv.Quote(v)
 				}
 				lines = append(lines, key+"="+v)
@@ -105,10 +107,10 @@ func runDump(ctx context.Context, k8sclient client.Client, namespace string, arg
 
 	sort.Strings(lines)
 
-	if dumpOpts.filename != "" {
-		f, err := os.Create(dumpOpts.filename)
+	if opts.filename != "" {
+		f, err := os.Create(opts.filename)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to open file. filename=%s", dumpOpts.filename)
+			return errors.Wrapf(err, "Failed to open file. filename=%s", opts.filename)
 		}
 		defer f.Close()
 
@@ -117,7 +119,7 @@ func runDump(ctx context.Context, k8sclient client.Client, namespace string, arg
 		for _, line := range lines {
 			_, err := w.WriteString(line + "\n")
 			if err != nil {
-				return errors.Wrapf(err, "Failed to write to file. filename=%s", dumpOpts.filename)
+				return errors.Wrapf(err, "Failed to write to file. filename=%s", opts.filename)
 			}
 		}
 

--- a/cmd/dump_test.go
+++ b/cmd/dump_test.go
@@ -110,7 +110,9 @@ rails-env="production"
 
 			var out bytes.Buffer
 
-			err := runDump(context.Background(), k8sclient, namespace, tc.args, &out)
+			opts := dumpOpts{}
+
+			err := runDump(context.Background(), k8sclient, namespace, tc.args, &out, &opts)
 
 			if tc.wantErr != nil {
 				if err == nil {

--- a/cmd/dump_test.go
+++ b/cmd/dump_test.go
@@ -12,17 +12,15 @@ import (
 
 func TestRunDump(t *testing.T) {
 	testcases := map[string]struct {
-		base64encode bool
-		args         []string
-		secret       *v1.Secret
-		secrets      *v1.SecretList
-		err          error
-		wantOut      string
-		wantErr      error
+		args    []string
+		secret  *v1.Secret
+		secrets *v1.SecretList
+		err     error
+		wantOut string
+		wantErr error
 	}{
 		"no secret arg": {
-			base64encode: false,
-			args:         []string{},
+			args: []string{},
 			secrets: &v1.SecretList{
 				Items: []v1.Secret{
 					{
@@ -65,8 +63,7 @@ token="thisistoken"
 		},
 
 		"one secret arg": {
-			base64encode: false,
-			args:         []string{"rails"},
+			args: []string{"rails"},
 			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "rails",

--- a/cmd/dump_test.go
+++ b/cmd/dump_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -12,15 +15,17 @@ import (
 
 func TestRunDump(t *testing.T) {
 	testcases := map[string]struct {
-		args    []string
-		secret  *v1.Secret
-		secrets *v1.SecretList
-		err     error
-		wantOut string
-		wantErr error
+		args     []string
+		filename string
+		secret   *v1.Secret
+		secrets  *v1.SecretList
+		err      error
+		wantOut  string
+		wantErr  error
 	}{
 		"no secret arg": {
-			args: []string{},
+			args:     []string{},
+			filename: "",
 			secrets: &v1.SecretList{
 				Items: []v1.Secret{
 					{
@@ -57,13 +62,15 @@ token="thisistoken"
 		},
 
 		"no secret arg and error": {
-			args:    []string{},
-			err:     fmt.Errorf("cannot retrieve secret rails"),
-			wantErr: fmt.Errorf("Failed to list secret.: cannot retrieve secret rails"),
+			args:     []string{},
+			filename: "",
+			err:      fmt.Errorf("cannot retrieve secret rails"),
+			wantErr:  fmt.Errorf("Failed to list secret.: cannot retrieve secret rails"),
 		},
 
 		"one secret arg": {
-			args: []string{"rails"},
+			args:     []string{"rails"},
+			filename: "",
 			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "rails",
@@ -81,14 +88,13 @@ rails-env="production"
 			wantErr: nil,
 		},
 
-		// TODO: Add testcase for --filename once I move filename to local variable
-
 		// TODO: Add testcase for --noquotes once I move noquotes to local variable
 
 		"one secret and error": {
-			args:    []string{"rails"},
-			err:     fmt.Errorf("cannot retrieve secret rails"),
-			wantErr: fmt.Errorf("Failed to get secret. name=rails: cannot retrieve secret rails"),
+			args:     []string{"rails"},
+			filename: "",
+			err:      fmt.Errorf("cannot retrieve secret rails"),
+			wantErr:  fmt.Errorf("Failed to get secret. name=rails: cannot retrieve secret rails"),
 		},
 	}
 
@@ -129,6 +135,106 @@ rails-env="production"
 					t.Logf("got:\n%s", out.String())
 					t.Fatalf("want %q, got %q", tc.wantOut, out.String())
 				}
+			}
+		})
+	}
+}
+
+func TestRunDump_dumpToFile(t *testing.T) {
+	testcases := map[string]struct {
+		args     []string
+		filename string
+		secret   *v1.Secret
+		secrets  *v1.SecretList
+		wantOut  string
+		wantBody string
+	}{
+		"dump to file": {
+			args:     []string{},
+			filename: ".env",
+			secrets: &v1.SecretList{
+				Items: []v1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default-token-12345",
+						},
+						Data: map[string][]byte{
+							"ca.crt":    []byte("thisiscrt"),
+							"namespace": []byte("test"),
+							"token":     []byte("thisistoken"),
+						},
+						Type: v1.SecretTypeServiceAccountToken,
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "rails",
+						},
+						Data: map[string][]byte{
+							"rails-env":    []byte("production"),
+							"database-url": []byte("postgres://example.com:5432/dbname"),
+						},
+						Type: v1.SecretTypeOpaque,
+					},
+				},
+			},
+			wantOut: "",
+			wantBody: `ca.crt="thisiscrt"
+database-url="postgres://example.com:5432/dbname"
+namespace="test"
+rails-env="production"
+token="thisistoken"
+`,
+		},
+	}
+
+	namespace := "test"
+
+	for name, tc := range testcases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			k8sclient := &fakeClient{
+				getSecretResponse:   tc.secret,
+				listSecretsResponse: tc.secrets,
+			}
+
+			var out bytes.Buffer
+
+			filename := filepath.Join(t.TempDir(), tc.filename)
+
+			opts := dumpOpts{
+				filename: filename,
+			}
+
+			err := runDump(context.Background(), k8sclient, namespace, tc.args, &out, &opts)
+
+			if err != nil {
+				t.Fatalf("want no error, got %q", err.Error())
+			}
+
+			if out.String() != tc.wantOut {
+				t.Logf("want:\n%s", tc.wantOut)
+				t.Logf("got:\n%s", out.String())
+				t.Fatalf("want %q, got %q", tc.wantOut, out.String())
+			}
+
+			if _, err := os.Stat(filename); err != nil {
+				t.Fatalf("want file %q but not found", filename)
+			}
+
+			f, err := os.Open(filename)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			b, err := ioutil.ReadAll(f)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(b) != tc.wantBody {
+				t.Fatalf("want %q, got %q", tc.wantBody, string(b))
 			}
 		})
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ func newRootCmd(in io.Reader, out io.Writer, args []string) *cobra.Command {
 
 	flags.Parse(args)
 
-	cmd.AddCommand(dumpCmd)
+	cmd.AddCommand(newDumpCmd(out))
 	cmd.AddCommand(newListCmd(out))
 	cmd.AddCommand(newLoadCmd(in, out))
 	cmd.AddCommand(newSetCmd(out))


### PR DESCRIPTION
## WHAT

Refactor dump command:

- Create `dumpCmd` by constructor
- Treat `dumpOpts` as local object instead of global object
- Add testcases with flags, since now we can treat those options in testcase local
