### PR TITLE
Customize User-Agent with k8sec version

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 
+	"github.com/dtan4/k8sec/version"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -40,6 +41,8 @@ func New(kubeconfig, context string) (*clientImpl, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	config.UserAgent = version.UserAgent()
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/version/version.go
+++ b/version/version.go
@@ -14,3 +14,8 @@ var (
 func String() string {
 	return fmt.Sprintf("k8sec version: %s, commit: %s, build at: %s", version, commit, date)
 }
+
+// UserAgent returns the version string in User-Agent header style
+func UserAgent() string {
+	return fmt.Sprintf("k8sec/%s", version)
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -16,3 +16,16 @@ func TestString(t *testing.T) {
 		t.Errorf("want: %q, got: %q", want, got)
 	}
 }
+
+func TestUserAgent(t *testing.T) {
+	version = "v0.1.0"
+	commit = "751282c0a11e8bacd2d1d9597728c6cb3f9147f8"
+	date = "2020-03-12T16:34:36Z"
+
+	want := "k8sec/v0.1.0"
+	got := UserAgent()
+
+	if got != want {
+		t.Errorf("want: %q, got: %q", want, got)
+	}
+}


### PR DESCRIPTION
Sets a custom `User-Agent` header with requests made by k8sec. This allows administrators to track usage of k8sec via apiserver's audit logs. 

By default, client-go attempts to assemble a user-agent string that contains information about its version/runtime:

https://github.com/kubernetes/client-go/blob/782ff783b635df54ddf44d55f3bd3e48eb4dcb9a/rest/config.go#L498-L506

If you'd like to keep this, there's an option to append your own user agent info to these defaults. However, since a given version of k8sec will be built with a specific version of client-go, it seems like just including the main tool version is the right move.